### PR TITLE
docs: add archived/deprecation notice pointing to kuhl-haus-magpie

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,18 @@ TODO:
 
 
 
+> [!WARNING]
+> **This project is no longer actively maintained and has been archived.**
+>
+> The functionality in `kuhl-haus-metrics` (and [kuhl-haus-canary](https://github.com/kuhl-haus/kuhl-haus-canary)) has been
+> consolidated into [Kuhl Haus Magpie](https://github.com/kuhl-haus/kuhl-haus-magpie).
+>
+> The core metrics module (`Metrics`, `CarbonPoster`, `CarbonConfig`, `get_logger`) lives at
+> [`src/kuhl_haus/magpie/metrics/`](https://github.com/kuhl-haus/kuhl-haus-magpie/tree/mainline/src/kuhl_haus/magpie/metrics)
+> in the Magpie mono-repo. Import paths change from `kuhl_haus.metrics.*` to `kuhl_haus.magpie.metrics.*`.
+>
+> No further updates will be made to this repository.
+
 # kuhl-haus-metrics
 
 [![License](https://img.shields.io/github/license/kuhl-haus/kuhl-haus-metrics)](https://github.com/kuhl-haus/kuhl-haus-metrics/blob/mainline/LICENSE.txt)


### PR DESCRIPTION
## Summary

Adds a deprecation/archive notice to the top of `README.md` announcing that `kuhl-haus-metrics` is no longer actively maintained.

## What's in the notice

- States the repo is archived and no longer maintained
- Points to [kuhl-haus-magpie](https://github.com/kuhl-haus/kuhl-haus-magpie) as the successor
- Links directly to the metrics module in Magpie: [`src/kuhl_haus/magpie/metrics/`](https://github.com/kuhl-haus/kuhl-haus-magpie/tree/mainline/src/kuhl_haus/magpie/metrics)
- Notes the import path change (`kuhl_haus.metrics.*` → `kuhl_haus.magpie.metrics.*`)

## Code comparison

The core source (`env.py`, `CarbonPoster`, `Metrics`, `CarbonConfig`, `get_logger`) is fully ported to Magpie with only import path changes. `GraphiteLogger` and `ThreadPool` (recorders/tasks) are also available in Magpie.

Consistent with the pattern established in kuhl-haus-canary.